### PR TITLE
Fix sample code

### DIFF
--- a/source/sdk_help/extend_editor/plugin_extensions/actions.md
+++ b/source/sdk_help/extend_editor/plugin_extensions/actions.md
@@ -172,14 +172,14 @@ extensions = {
 
 ## Run an existing JavaScript function
 
-To make your action run a JavaScript function from a module defined in a separate *.js* file, use the `module` type:
+To make your action run a JavaScript function from a module defined in a separate *.js* file, use the `js` type and specify the file location with module definition:
 
 ~~~{sjson}
 extensions = {
 	actions = [
 		{
 			name = "recompile-all-resources"
-		    type = "module"
+		    type = "js"
 			module = "my-plugin-javascript-file"
 			function_name = "myFunctionName"
 		}


### PR DESCRIPTION
"Run an existing JavaScript function", sample code uses 

type = "module".

But it will be an error in 1.8. need to use 

type = "js"

